### PR TITLE
GMAIL_USERNAMEとGMAIL_PASSWORDを.envに

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,8 +84,8 @@ Rails.application.configure do
     port:                 587,
     address:              "smtp.gmail.com",
     domain:               "smtp.gmail.com",
-    user_name:            "mysongjournalconfirmable@gmail.com",
-    password:             "odni tvfp gzcc prvo",
+    user_name:            ENV["GMAIL_USERNAME"],
+    password:             ENV["GMAIL_PASSWORD"],
     authentication:       "login",
     enable_starttls_auto: true
   }


### PR DESCRIPTION
GMAIL_USERNAMEとGMAIL_PASSWORDを.envに追加し、

```
  config.web_console.whitelisted_ips = "192.168.65.0/24"
  config.action_mailer.delivery_method = :smtp
  config.action_mailer.smtp_settings = {
    port:                 587,
    address:              "smtp.gmail.com",
    domain:               "smtp.gmail.com",
    user_name:            ENV["GMAIL_USERNAME"],
    password:             ENV["GMAIL_PASSWORD"],
    authentication:       "login",
    enable_starttls_auto: true
  }
  config.log_level = :debug
end
```

このように記載しました