### PR TITLE
devise-パスワードリセット・アカウント確認メール機能の実装デプロイ環境

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,9 +79,11 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: "https://my-song-journal.fly.dev"}
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -103,4 +105,14 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :port => 587,
+    :domain => 'smtp.gmail.com',
+    :address => "smtp.gmail.com",
+    :user_name => ENV["GMAIL_USERNAME"] ,
+    :password => ENV["GMAIL_PASSWORD"] ,
+    :authentication => :login,
+    :enable_starttls_auto => true
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,7 +79,7 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "https://my-song-journal.fly.dev"}
+  config.action_mailer.default_url_options = { host: "https://my-song-journal.fly.dev" }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
@@ -107,12 +107,12 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :port => 587,
-    :domain => 'smtp.gmail.com',
-    :address => "smtp.gmail.com",
-    :user_name => ENV["GMAIL_USERNAME"] ,
-    :password => ENV["GMAIL_PASSWORD"] ,
-    :authentication => :login,
-    :enable_starttls_auto => true
+    port: 587,
+    domain: "smtp.gmail.com",
+    address: "smtp.gmail.com",
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
   }
 end


### PR DESCRIPTION
My-Song-Journal/config/environments/production.rbに
```
config.action_mailer.default_url_options = { host: "https://my-song-journal.fly.dev"}
```
と
```
config.action_mailer.delivery_method = :smtp
  config.action_mailer.smtp_settings = {
    :port => 587,
    :domain => 'smtp.gmail.com',
    :address => "smtp.gmail.com",
    :user_name => ENV["GMAIL_USERNAME"] ,
    :password => ENV["GMAIL_PASSWORD"] ,
    :authentication => :login,
    :enable_starttls_auto => true
  }
end
```
の記載をしてデプロイ環境でもパスワードリセット・アカウント確認メール機能の実装をしました